### PR TITLE
Extend TabWidget's style sheet options (#6730)

### DIFF
--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -187,6 +187,7 @@ lmms--gui--TabWidget {
 	qproperty-tabText: rgba(255, 255, 255, 180);
 	qproperty-tabTitleText: #fff;
 	qproperty-tabSelected: #61666b;
+	qproperty-tabTextSelected: rgba(255, 255, 255, 180);
 	qproperty-tabBackground: #3c434b;
 	qproperty-tabBorder: #3c434b;
 }

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -218,7 +218,8 @@ lmms--gui--TabWidget {
 	background-color: #262b30;
 	qproperty-tabText: rgba(255, 255, 255, 180);
 	qproperty-tabTitleText: #fff;
-	qproperty-tabSelected: #323940;
+	qproperty-tabSelected: #1c4933;
+	qproperty-tabTextSelected: rgba(255, 255, 255, 255);
 	qproperty-tabBackground: #181b1f;
 	qproperty-tabBorder: #181b1f;
 }

--- a/include/TabWidget.h
+++ b/include/TabWidget.h
@@ -59,6 +59,7 @@ public:
 	Q_PROPERTY( QColor tabText READ tabText WRITE setTabText)
 	Q_PROPERTY( QColor tabTitleText READ tabTitleText WRITE setTabTitleText)
 	Q_PROPERTY( QColor tabSelected READ tabSelected WRITE setTabSelected)
+	Q_PROPERTY( QColor tabTextSelected READ tabTextSelected WRITE setTabTextSelected)
 	Q_PROPERTY( QColor tabBackground READ tabBackground WRITE setTabBackground)
 	Q_PROPERTY( QColor tabBorder READ tabBorder WRITE setTabBorder)
 
@@ -68,6 +69,8 @@ public:
 	void setTabTitleText( const QColor & c );
 	QColor tabSelected() const;
 	void setTabSelected( const QColor & c );
+	QColor tabTextSelected() const;
+	void setTabTextSelected( const QColor & c );
 	QColor tabBackground() const;
 	void setTabBackground( const QColor & c );
 	QColor tabBorder() const;
@@ -104,6 +107,7 @@ private:
 	QColor m_tabText;       // The color of the tabs' text.
 	QColor m_tabTitleText;  // The color of the TabWidget's title text.
 	QColor m_tabSelected;   // The highlighting color for the selected tab.
+	QColor m_tabTextSelected;// The text color for the selected tab.
 	QColor m_tabBackground; // The TabWidget's background color.
 	QColor m_tabBorder;     // The TabWidget's borders color.
 } ;

--- a/src/gui/widgets/TabWidget.cpp
+++ b/src/gui/widgets/TabWidget.cpp
@@ -48,6 +48,7 @@ TabWidget::TabWidget(const QString & caption, QWidget * parent, bool usePixmap,
 	m_tabText( 0, 0, 0 ),
 	m_tabTitleText( 0, 0, 0 ),
 	m_tabSelected( 0, 0, 0 ),
+	m_tabTextSelected( 0, 0, 0 ),
 	m_tabBackground( 0, 0, 0 ),
 	m_tabBorder( 0, 0, 0 )
 {
@@ -274,10 +275,15 @@ void TabWidget::paintEvent( QPaintEvent * pe )
 			if( it.key() == m_activeTab )
 			{
 				p.fillRect( tab_x_offset, 2, ( *it ).nwidth - 6, m_tabbarHeight - 4, tabSelected() );
+				p.setPen(tabTextSelected());
+				p.drawText( tab_x_offset + 3, m_tabheight + 1, ( *it ).name );
 			}
-
-			// Draw text
-			p.drawText( tab_x_offset + 3, m_tabheight + 1, ( *it ).name );
+			else
+			{
+				// Draw text
+				p.setPen( tabText() );
+				p.drawText( tab_x_offset + 3, m_tabheight + 1, ( *it ).name );
+			}
 		}
 
 		// Next tab's horizontal position
@@ -390,6 +396,18 @@ QColor TabWidget::tabSelected() const
 void TabWidget::setTabSelected( const QColor & c )
 {
 	m_tabSelected = c;
+}
+
+// Return the text color of the selected tab
+QColor TabWidget::tabTextSelected() const
+{
+	return m_tabTextSelected;
+}
+
+// Set the text color of the selected tab
+void TabWidget::setTabTextSelected( const QColor & c )
+{
+	m_tabTextSelected = c;
 }
 
 // Return the color to be used for the TabWidget's background


### PR DESCRIPTION
Extend the `TabWidget` class so that the text color of the selected tab can be set in the style sheet. Adjust the paint method to make use of the new property.

Adjust the default style sheet as follows:
* Background color of the selected tab is the green of the knobs
* Text color of the selected tab is full on white

Adjust the classic style sheet in such a way that nothing changes, i.e. the text colors of the selected tab and the other ones are the same.