### PR TITLE
Fix HiDPI issues for menus

### DIFF
--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -115,7 +115,6 @@ QSplashScreen QLabel {
 QMenu {
 	border-top: 2px solid #08993E;
 	background-color: #15191c;
-	font-size: 11px;
 }
 
 QMenu::separator {
@@ -133,15 +132,12 @@ QMenu::item {
 
 QMenu::item:selected {
 	color: #d1d8e4;
-	font-weight: normal;
 	background-color: #21272b;
 }
 
 QMenu::item:disabled {
 	color: #515459;
 	background-color: #262b30;
-	font-size: 12px;
-	font-weight: normal;
 	padding: 4px 32px 4px 20px;
 }
 

--- a/src/gui/menus/MidiPortMenu.cpp
+++ b/src/gui/menus/MidiPortMenu.cpp
@@ -34,7 +34,6 @@ MidiPortMenu::MidiPortMenu( MidiPort::Modes _mode ) :
 	ModelView( nullptr, this ),
 	m_mode( _mode )
 {
-	setFont( pointSize<9>( font() ) );
 	connect( this, SIGNAL(triggered(QAction*)),
 			this, SLOT(activatedPort(QAction*)));
 }

--- a/src/gui/tracks/TrackOperationsWidget.cpp
+++ b/src/gui/tracks/TrackOperationsWidget.cpp
@@ -64,7 +64,6 @@ TrackOperationsWidget::TrackOperationsWidget( TrackView * parent ) :
 				"to begin a new drag'n'drop action." ).arg(UI_CTRL_KEY) );
 
 	auto toMenu = new QMenu(this);
-	toMenu->setFont( pointSize<9>( toMenu->font() ) );
 	connect( toMenu, SIGNAL(aboutToShow()), this, SLOT(updateMenu()));
 
 

--- a/src/gui/widgets/ComboBox.cpp
+++ b/src/gui/widgets/ComboBox.cpp
@@ -70,7 +70,6 @@ ComboBox::ComboBox( QWidget * _parent, const QString & _name ) :
 	}
 
 	setFont( pointSize<9>( font() ) );
-	m_menu.setFont( pointSize<8>( m_menu.font() ) );
 
 	connect( &m_menu, SIGNAL(triggered(QAction*)),
 				this, SLOT(setItem(QAction*)));


### PR DESCRIPTION
Menus now use the size that users have set globally for their applications. This is accomplished by removing the fixed font size definition (in points) for `QMenu` in `style.css`.

In some places the menus had been set to hard coded font sizes. This code is also removed and applies to the following menus:
* Combo box menus
* Track operation widget (gear icon on tracks)
* The MIDI port menu