### PR TITLE
Fix HiDPI issue of sample track window

### DIFF
--- a/src/gui/SampleTrackWindow.cpp
+++ b/src/gui/SampleTrackWindow.cpp
@@ -74,7 +74,6 @@ SampleTrackWindow::SampleTrackWindow(SampleTrackView * tv) :
 
 	// setup line edit for changing sample track name
 	m_nameLineEdit = new QLineEdit;
-	m_nameLineEdit->setFont(pointSize<9>(m_nameLineEdit->font()));
 	connect(m_nameLineEdit, SIGNAL(textChanged(const QString&)),
 				this, SLOT(textChanged(const QString&)));
 


### PR DESCRIPTION
Fix one of the HiDPI issues of the sample track window by removing the hard coded font size of the name line edit.