### PR TITLE
HiDPI fixes for elements based on QTreeView

### DIFF
--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -9,7 +9,6 @@ QLabel, QTreeWidget, QListWidget, QGroupBox, QMenuBar {
 
 QTreeView {
 	outline: none;
-	font-size: 12px;
 }
 
 QTreeWidget::item {
@@ -42,7 +41,7 @@ QMdiArea {
 
 lmms--gui--FileBrowser QCheckBox
 {
-	font-size: 10px;
+	font-size: 8pt;
 	color: white;
 }
 


### PR DESCRIPTION
Fix the HiDPI problems for elements that are based on QTreeView by removing the fixed point based font size from the style sheet. This affects:
* The file browser
* The headings of the plugin browser
* The patch selection dialogs for GigPlayer and SoundFont player

Also make the text size of the check boxes for user content and factory content based on a point size instead of a pixel size.