### PR TITLE
Optimize locking in NotePlayHandle during tempo change

### DIFF
--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -162,9 +162,9 @@ void Song::setTempo()
 		auto nph = dynamic_cast<NotePlayHandle*>(playHandle);
 		if( nph && !nph->isReleased() )
 		{
-			nph->lock();
+			// No locking needed - requestChangeInModel() already ensures
+			// exclusive access to all PlayHandles
 			nph->resize( tempo );
-			nph->unlock();
 		}
 	}
 	Engine::audioEngine()->doneChangeInModel();


### PR DESCRIPTION
Removed unnecessary locking around tempo change operation.